### PR TITLE
Add workaround for Julia 1.12.1

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -32,7 +32,9 @@ jobs:
             - 1.10    # Latest 1.10 release
             - 1.11.0  # Earliest 1.11 release
             - 1.11    # Latest 1.11 release 
-            - 1.12-nightly
+            - 1.12.0  # Earliest 1.12 release
+            - 1.12    # Latest 1.12 release
+            - 1.13-nightly
           project: test
           if-missing: error
 

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -34,7 +34,7 @@ jobs:
             - 1.11    # Latest 1.11 release 
             - 1.12.0  # Earliest 1.12 release
             - 1.12    # Latest 1.12 release
-            - 1.13-nightly
+            # - 1.13-nightly  # No corresponding Docker image currently exists (2025-11-06)
           project: test
           if-missing: error
 

--- a/pkg-precompile.jl
+++ b/pkg-precompile.jl
@@ -274,6 +274,7 @@ setdiff!(precompile_pkgs, path_tracked_pkgs)
 
 # Julia 1.12.1 no longer allows initiating precompilation for packages which are indirect
 # dependencies. It seems reasonable take this approach for all versions of Julia.
+# This change was added in https://github.com/JuliaLang/julia/pull/59212
 if VERSION >= v"1.12.1"
     indirect_dep_pkgs = [PkgId(uuid, dep.name) for (uuid, dep) in Pkg.dependencies(env)
                      if !dep.is_direct_dep]

--- a/pkg-precompile.jl
+++ b/pkg-precompile.jl
@@ -273,8 +273,8 @@ path_tracked_pkgs = [PkgId(uuid, dep.name) for (uuid, dep) in Pkg.dependencies(e
 setdiff!(precompile_pkgs, path_tracked_pkgs)
 
 # Julia 1.12.1 no longer allows initiating precompilation for packages which are indirect
-# dependencies. It seems reasonable take this approach for all versions of Julia.
-# This change was added in https://github.com/JuliaLang/julia/pull/59212
+# dependencies. It is probably reasonable to use this approach on all versions of Julia. We
+# can make that call once we get feedback on: https://github.com/JuliaLang/julia/issues/60077
 if VERSION >= v"1.12.1"
     indirect_dep_pkgs = [PkgId(uuid, dep.name) for (uuid, dep) in Pkg.dependencies(env)
                      if !dep.is_direct_dep]

--- a/pkg-precompile.jl
+++ b/pkg-precompile.jl
@@ -277,7 +277,7 @@ setdiff!(precompile_pkgs, path_tracked_pkgs)
 # can make that call once we get feedback on: https://github.com/JuliaLang/julia/issues/60077
 if VERSION >= v"1.12.1"
     indirect_dep_pkgs = [PkgId(uuid, dep.name) for (uuid, dep) in Pkg.dependencies(env)
-                     if !dep.is_direct_dep]
+                         if !dep.is_direct_dep]
     setdiff!(precompile_pkgs, indirect_dep_pkgs)
 end
 

--- a/pkg-precompile.jl
+++ b/pkg-precompile.jl
@@ -272,6 +272,14 @@ path_tracked_pkgs = [PkgId(uuid, dep.name) for (uuid, dep) in Pkg.dependencies(e
                      if dep.is_tracking_path]
 setdiff!(precompile_pkgs, path_tracked_pkgs)
 
+# Julia 1.12.1 no longer allows initiating precompilation for packages which are indirect
+# dependencies. It seems reasonable take this approach for all versions of Julia.
+if VERSION >= v"1.12.1"
+    indirect_dep_pkgs = [PkgId(uuid, dep.name) for (uuid, dep) in Pkg.dependencies(env)
+                     if !dep.is_direct_dep]
+    setdiff!(precompile_pkgs, indirect_dep_pkgs)
+end
+
 # Skip precompilation when the package list is empty. Typically, this would make
 # `Pkg.precompile` compile everything. Unfortunately, `Pkg.precompile` on newer versions of
 # Julia (1.11.0+) display the full list of packages to precompile which adds noise to the

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,10 +8,11 @@ using UUIDs: UUID
 # https://hub.docker.com/_/julia/tags?name=1.12.0-beta4-bookworm
 const JULIA_VERSION = if VERSION == Base.thispatch(VERSION)
     string(VERSION)
-elseif v"1.12.0-" <= VERSION <= v"1.12.0"
+elseif v"1.12.0-" <= VERSION < v"1.12.0"
     "1.12.0-beta4"
 else
-    error("Pre-release versions of Julia need to specify their corresponding Docker tag")
+    error("Pre-release version of Julia ($VERSION) requires a hard-coded rule specifying " *
+          "the corresponding Docker tag")
 end
 
 # These versions of Julia require a `src/$(name).jl` to be present to instantiate a named

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,10 +2,16 @@ using Base: PkgId
 using Test
 using UUIDs: UUID
 
-const JULIA_VERSION = if v"1.12.0-" <= VERSION <= v"1.12.0"
-    "1.12.0-beta1"
-else
+# Needs to to match a Docker tag for the `julia` image
+# (i.e. `julia:$(JULIA_VERSION)-bookworm`). For pre-releases a manual tag rule can be added
+# here by searching the Docker Hub website for a corresponding tag:
+# https://hub.docker.com/_/julia/tags?name=1.12.0-beta4-bookworm
+const JULIA_VERSION = if VERSION == Base.thispatch(VERSION)
     string(VERSION)
+elseif v"1.12.0-" <= VERSION <= v"1.12.0"
+    "1.12.0-beta4"
+else
+    error("Pre-release versions of Julia need to specify their corresponding Docker tag")
 end
 
 # These versions of Julia require a `src/$(name).jl` to be present to instantiate a named


### PR DESCRIPTION
Adding CI tests against the latest releases of Julia to ensure we've retained compatibility with Julia 1.12.0 and 1.12.1.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211867634077782